### PR TITLE
fix: exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supabase/sql-to-rest",
   "version": "0.1.7",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "type": "module",
@@ -25,9 +25,9 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "default": "./dist/index.cjs"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Fixes package exports to use the correct file extension (`.cjs` for CommonJS, `.js` for ESM)